### PR TITLE
Fix typography... again

### DIFF
--- a/utils/typography.js
+++ b/utils/typography.js
@@ -8,13 +8,14 @@ const options = {
     {
       name: 'Lora',
       styles: [
+        '400',
+        '400italic',
         '700',
       ],
     },
     {
       name: 'Open Sans',
       styles: [
-        '400',
         '700',
       ],
     },


### PR DESCRIPTION
Gah, got it wrong again. Didn't notice that _Lora_ was the body font not Open Sans.

Tested it locally this time.

<img width="730" alt="screen shot 2016-05-06 at 9 41 22 am" src="https://cloud.githubusercontent.com/assets/71047/15079672/d463280e-136e-11e6-8697-816dfb0c1bf4.png">
